### PR TITLE
Add simple study notes library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-<div align="center">
+# Ateismos Study Library
 
-# Jooooooooo 
+This repository contains a simple Python library for managing study notes.
 
- ## **Wie bist du hier gelandet?**   
-    
-##  **Mein Discord**
-<div align="center">
-    <a href="https://discord.com/users/ateismos" target="_blank">
-        <img src="https://img.shields.io/badge/Discord-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord">
-</div>
+## Usage
 
+```
+from studylib import StudyLibrary
+
+library = StudyLibrary()  # by default uses 'notes.json'
+library.add("First Note", "This is an example note.")
+all_notes = library.list()
+search_results = library.search("example")
+```
+
+Notes are stored in a JSON file which is automatically created in the current directory.

--- a/studylib/__init__.py
+++ b/studylib/__init__.py
@@ -1,0 +1,5 @@
+"""Study Library for storing notes."""
+
+from .notes import Note, StudyLibrary
+
+__all__ = ["Note", "StudyLibrary"]

--- a/studylib/notes.py
+++ b/studylib/notes.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+import json
+from typing import List, Optional
+
+@dataclass
+class Note:
+    id: int
+    title: str
+    content: str
+    tags: List[str] = field(default_factory=list)
+
+class StudyLibrary:
+    """Simple library for storing study notes."""
+
+    def __init__(self, path: str = "notes.json"):
+        self.path = Path(path)
+        self.notes: List[Note] = []
+        self._load()
+
+    def _load(self) -> None:
+        if self.path.exists():
+            with self.path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+                self.notes = [Note(**item) for item in data]
+        else:
+            self.notes = []
+
+    def _save(self) -> None:
+        with self.path.open("w", encoding="utf-8") as f:
+            json.dump([asdict(n) for n in self.notes], f, ensure_ascii=False, indent=2)
+
+    def add(self, title: str, content: str, tags: Optional[List[str]] = None) -> Note:
+        """Add a new note and return it."""
+        next_id = self.notes[-1].id + 1 if self.notes else 1
+        note = Note(id=next_id, title=title, content=content, tags=tags or [])
+        self.notes.append(note)
+        self._save()
+        return note
+
+    def list(self) -> List[Note]:
+        """Return all notes."""
+        return list(self.notes)
+
+    def search(self, keyword: str) -> List[Note]:
+        """Return notes that contain keyword in title, content or tags."""
+        keyword = keyword.lower()
+        result = []
+        for note in self.notes:
+            if (
+                keyword in note.title.lower()
+                or keyword in note.content.lower()
+                or any(keyword in tag.lower() for tag in note.tags)
+            ):
+                result.append(note)
+        return result
+
+    def remove(self, note_id: int) -> None:
+        """Remove a note by its id."""
+        self.notes = [n for n in self.notes if n.id != note_id]
+        self._save()


### PR DESCRIPTION
## Summary
- add a lightweight Python library (`studylib`) for managing notes
- update README with usage instructions

## Testing
- `python3 -m py_compile studylib/notes.py`
- `python3 - <<'EOF'
from studylib import StudyLibrary
lib = StudyLibrary('test_notes.json')
lib.add('test title', 'test content', ['tag1'])
print(len(lib.list()))
print(lib.search('test')[0].content)
lib.remove(1)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687cf5ef30108321bdf9db7e18c85ae4